### PR TITLE
Less verbose logs from `make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -932,8 +932,7 @@ ifneq "$(1)" "%"
 # instead include $(runtime_BUILT_HEADERS) in the order only dependencies
 # to ensure that they exist before dependencies are computed.
 $(DEPDIR)/$(1).$(D): runtime/%.c | $(DEPDIR)/runtime $(runtime_BUILT_HEADERS)
-	$$(info CCDEPS $$< -> $$@)
-	@$$(DEP_CC) $$(OC_CPPFLAGS) $$(CPPFLAGS) $$< -MT \
+	$$(V_CCDEPS)$$(DEP_CC) $$(OC_CPPFLAGS) $$(CPPFLAGS) $$< -MT \
 	  'runtime/$$*$(subst runtime/%,,$(1)).$(O)' -MF $$@
 endif # ifneq "$(1)" "%"
 $(1).$(O): $(2).c
@@ -942,8 +941,7 @@ $(1).$(O): $(2).c \
   $(runtime_CONFIGURED_HEADERS) $(runtime_BUILT_HEADERS) \
   $(RUNTIME_HEADERS)
 endif # ifeq "$(COMPUTE_DEPS)" "true"
-	$$(info CC $$< -> $$@)
-	@$$(CC) -c $$(OC_CFLAGS) $$(CFLAGS) $$(OC_CPPFLAGS) $$(CPPFLAGS) \
+	$$(V_CC)$$(CC) -c $$(OC_CFLAGS) $$(CFLAGS) $$(OC_CPPFLAGS) $$(CPPFLAGS) \
 	  $$(OUTPUTOBJ)$$@ $$<
 endef
 
@@ -1543,16 +1541,13 @@ endif
 # Default rules
 
 %.cmo: %.ml
-	$(info OCAMLC $<)
-	@$(CAMLC) $(OC_COMMON_CFLAGS) -I $(@D) $(INCLUDES) -c $<
+	$(V_OCAMLC)$(CAMLC) $(OC_COMMON_CFLAGS) -I $(@D) $(INCLUDES) -c $<
 
 %.cmi: %.mli
-	$(info OCAMLC $<)
-	@$(CAMLC) $(OC_COMMON_CFLAGS) -I $(@D) $(INCLUDES) -c $<
+	$(V_OCAMLC)$(CAMLC) $(OC_COMMON_CFLAGS) -I $(@D) $(INCLUDES) -c $<
 
 %.cmx: %.ml
-	$(info OCAMLOPT $<)
-	@$(COMPILE_NATIVE_MODULE) -c $<
+	$(V_OCAMLOPT)$(COMPILE_NATIVE_MODULE) -c $<
 
 partialclean::
 	for d in utils parsing typing bytecomp asmcomp middle_end file_formats \

--- a/Makefile
+++ b/Makefile
@@ -73,22 +73,22 @@ include compilerlibs/Makefile.compilerlibs
 
 utils/config.ml: \
   utils/config_$(if $(filter true,$(IN_COREBOOT_CYCLE)),boot,main).ml
-	cp $< $@
+	$(V_GEN)cp $< $@
 utils/config_boot.ml: utils/config.fixed.ml utils/config.common.ml
-	cat $^ > $@
+	$(V_GEN)cat $^ > $@
 
 utils/config_main.ml: utils/config.generated.ml utils/config.common.ml
-	cat $^ > $@
+	$(V_GEN)cat $^ > $@
 
 .PHONY: reconfigure
 reconfigure:
 	ac_read_git_config=true ./configure $(CONFIGURE_ARGS)
 
 utils/domainstate.ml: utils/domainstate.ml.c runtime/caml/domain_state.tbl
-	$(CPP) -I runtime/caml $< > $@
+	$(V_GEN)$(CPP) -I runtime/caml $< > $@
 
 utils/domainstate.mli: utils/domainstate.mli.c runtime/caml/domain_state.tbl
-	$(CPP) -I runtime/caml $< > $@
+	$(V_GEN)$(CPP) -I runtime/caml $< > $@
 
 configure: tools/autogen configure.ac aclocal.m4 build-aux/ocaml_version.m4
 	$<
@@ -493,11 +493,11 @@ ocaml_MODULES = toplevel/topstart
 .INTERMEDIATE: ocaml.tmp
 ocaml.tmp: OC_BYTECODE_LDFLAGS += -I toplevel/byte -linkall
 ocaml.tmp: $(ocaml_LIBRARIES:=.cma) $(ocaml_MODULES:=.cmo)
-	$(LINK_BYTECODE_PROGRAM) -o $@ $^
+	$(V_LINKC)$(LINK_BYTECODE_PROGRAM) -o $@ $^
 
 $(eval $(call PROGRAM_SYNONYM,ocaml))
 ocaml$(EXE): $(expunge) ocaml.tmp
-	- $(OCAMLRUN) $^ $@ $(PERVASIVES)
+	- $(V_GEN)$(OCAMLRUN) $^ $@ $(PERVASIVES)
 
 partialclean::
 	rm -f ocaml ocaml.exe
@@ -541,7 +541,7 @@ beforedepend:: parsing/lexer.ml
 
 lambda/runtimedef.ml: lambda/generate_runtimedef.sh runtime/caml/fail.h \
     runtime/primitives
-	$^ > $@
+	$(V_GEN)$^ > $@
 
 partialclean::
 	rm -f lambda/runtimedef.ml
@@ -551,25 +551,25 @@ beforedepend:: lambda/runtimedef.ml
 # Choose the right machine-dependent files
 
 asmcomp/arch.mli: asmcomp/$(ARCH)/arch.mli
-	cd asmcomp; $(LN) $(ARCH)/arch.mli .
+	$(V_LN)cd asmcomp; $(LN) $(ARCH)/arch.mli .
 
 asmcomp/arch.ml: asmcomp/$(ARCH)/arch.ml
-	cd asmcomp; $(LN) $(ARCH)/arch.ml .
+	$(V_LN)cd asmcomp; $(LN) $(ARCH)/arch.ml .
 
 asmcomp/proc.ml: asmcomp/$(ARCH)/proc.ml
-	cd asmcomp; $(LN) $(ARCH)/proc.ml .
+	$(V_LN)cd asmcomp; $(LN) $(ARCH)/proc.ml .
 
 asmcomp/selection.ml: asmcomp/$(ARCH)/selection.ml
-	cd asmcomp; $(LN) $(ARCH)/selection.ml .
+	$(V_LN)cd asmcomp; $(LN) $(ARCH)/selection.ml .
 
 asmcomp/CSE.ml: asmcomp/$(ARCH)/CSE.ml
-	cd asmcomp; $(LN) $(ARCH)/CSE.ml .
+	$(V_LN)cd asmcomp; $(LN) $(ARCH)/CSE.ml .
 
 asmcomp/reload.ml: asmcomp/$(ARCH)/reload.ml
-	cd asmcomp; $(LN) $(ARCH)/reload.ml .
+	$(V_LN)cd asmcomp; $(LN) $(ARCH)/reload.ml .
 
 asmcomp/scheduling.ml: asmcomp/$(ARCH)/scheduling.ml
-	cd asmcomp; $(LN) $(ARCH)/scheduling.ml .
+	$(V_LN)cd asmcomp; $(LN) $(ARCH)/scheduling.ml .
 
 # Preprocess the code emitters
 cvt_emit = tools/cvt_emit$(EXE)
@@ -577,7 +577,7 @@ cvt_emit = tools/cvt_emit$(EXE)
 beforedepend:: tools/cvt_emit.ml
 
 asmcomp/emit.ml: asmcomp/$(ARCH)/emit.mlp $(cvt_emit)
-	echo \# 1 \"asmcomp/$(ARCH)/emit.mlp\" > $@
+	$(V_GEN)echo \# 1 \"asmcomp/$(ARCH)/emit.mlp\" > $@ && \
 	$(OCAMLRUN) $(cvt_emit) < $< >> $@ \
 	|| { rm -f $@; exit 2; }
 
@@ -765,7 +765,7 @@ endif
 ## Generated non-object files
 
 runtime/ld.conf: $(ROOTDIR)/Makefile.config
-	echo "$(STUBLIBDIR)" > $@
+	$(V_GEN)echo "$(STUBLIBDIR)" > $@ && \
 	echo "$(LIBDIR)" >> $@
 
 # If primitives contain duplicated lines (e.g. because the code is defined
@@ -793,10 +793,10 @@ runtime/primitives: \
   $(shell runtime/gen_primitives.sh > runtime/primitives.new; \
                     cmp -s runtime/primitives runtime/primitives.new || \
                     echo runtime/primitives.new)
-	cp $^ $@
+	$(V_GEN)cp $^ $@
 
 runtime/prims.c : runtime/primitives
-	(echo '#define CAML_INTERNALS'; \
+	$(V_GEN)(echo '#define CAML_INTERNALS'; \
          echo '#include "caml/mlvalues.h"'; \
 	 echo '#include "caml/prims.h"'; \
 	 sed -e 's/.*/extern value &();/' $<; \
@@ -808,7 +808,7 @@ runtime/prims.c : runtime/primitives
 	 echo '  0 };') > $@
 
 runtime/caml/opnames.h : runtime/caml/instruct.h
-	tr -d '\r' < $< | \
+	$(V_GEN)tr -d '\r' < $< | \
 	sed -e '/\/\*/d' \
 	    -e '/^#/d' \
 	    -e 's/enum /static char * names_of_/' \
@@ -817,7 +817,7 @@ runtime/caml/opnames.h : runtime/caml/instruct.h
 
 # runtime/caml/jumptbl.h is required only if you have GCC 2.0 or later
 runtime/caml/jumptbl.h : runtime/caml/instruct.h
-	tr -d '\r' < $< | \
+	$(V_GEN)tr -d '\r' < $< | \
 	sed -n -e '/^  /s/ \([A-Z]\)/ \&\&lbl_\1/gp' \
 	       -e '/^}/q' > $@
 
@@ -828,64 +828,64 @@ SAK_CFLAGS ?= $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS)
 SAK_LINK ?= $(MKEXE_VIA_CC)
 
 $(SAK): runtime/sak.$(O)
-	$(call SAK_LINK,$@,$^)
+	$(V_MKEXE)$(call SAK_LINK,$@,$^)
 
 runtime/sak.$(O): runtime/sak.c runtime/caml/misc.h runtime/caml/config.h
-	$(SAK_CC) -c $(SAK_CFLAGS) $(OUTPUTOBJ)$@ $<
+	$(V_CC)$(SAK_CC) -c $(SAK_CFLAGS) $(OUTPUTOBJ)$@ $<
 
 C_LITERAL = $(shell $(SAK) encode-C-literal '$(1)')
 
 runtime/build_config.h: $(ROOTDIR)/Makefile.config $(SAK)
-	echo '/* This file is generated from $(ROOTDIR)/Makefile.config */' > $@
-	echo '#define OCAML_STDLIB_DIR $(call C_LITERAL,$(LIBDIR))' >> $@
+	$(V_GEN)echo '/* This file is generated from $(ROOTDIR)/Makefile.config */' > $@ && \
+	echo '#define OCAML_STDLIB_DIR $(call C_LITERAL,$(LIBDIR))' >> $@ && \
 	echo '#define HOST "$(HOST)"' >> $@
 
 ## Runtime libraries and programs
 
 runtime/ocamlrun$(EXE): runtime/prims.$(O) runtime/libcamlrun.$(A)
-	$(MKEXE) -o $@ $^ $(BYTECCLIBS)
+	$(V_MKEXE)$(MKEXE) -o $@ $^ $(BYTECCLIBS)
 
 runtime/ocamlruns$(EXE): runtime/prims.$(O) runtime/libcamlrun_non_shared.$(A)
-	$(call MKEXE_VIA_CC,$@,$^ $(BYTECCLIBS))
+	$(V_MKEXE)$(call MKEXE_VIA_CC,$@,$^ $(BYTECCLIBS))
 
 runtime/libcamlrun.$(A): $(libcamlrun_OBJECTS)
-	$(call MKLIB,$@, $^)
+	$(V_MKLIB)$(call MKLIB,$@, $^)
 
 runtime/libcamlrun_non_shared.$(A): $(libcamlrun_non_shared_OBJECTS)
-	$(call MKLIB,$@, $^)
+	$(V_MKLIB)$(call MKLIB,$@, $^)
 
 runtime/ocamlrund$(EXE): runtime/prims.$(O) runtime/libcamlrund.$(A)
-	$(MKEXE) $(MKEXEDEBUGFLAG) -o $@ $^ $(BYTECCLIBS)
+	$(V_MKEXE)$(MKEXE) $(MKEXEDEBUGFLAG) -o $@ $^ $(BYTECCLIBS)
 
 runtime/libcamlrund.$(A): $(libcamlrund_OBJECTS)
-	$(call MKLIB,$@, $^)
+	$(V_MKLIB)$(call MKLIB,$@, $^)
 
 runtime/ocamlruni$(EXE): runtime/prims.$(O) runtime/libcamlruni.$(A)
-	$(MKEXE) -o $@ $^ $(INSTRUMENTED_RUNTIME_LIBS) $(BYTECCLIBS)
+	$(V_MKEXE)$(MKEXE) -o $@ $^ $(INSTRUMENTED_RUNTIME_LIBS) $(BYTECCLIBS)
 
 runtime/libcamlruni.$(A): $(libcamlruni_OBJECTS)
-	$(call MKLIB,$@, $^)
+	$(V_MKLIB)$(call MKLIB,$@, $^)
 
 runtime/libcamlrun_pic.$(A): $(libcamlrunpic_OBJECTS)
-	$(call MKLIB,$@, $^)
+	$(V_MKLIB)$(call MKLIB,$@, $^)
 
 runtime/libcamlrun_shared.$(SO): $(libcamlrunpic_OBJECTS)
-	$(MKDLL) -o $@ $^ $(BYTECCLIBS)
+	$(V_MKDLL)$(MKDLL) -o $@ $^ $(BYTECCLIBS)
 
 runtime/libasmrun.$(A): $(libasmrun_OBJECTS)
-	$(call MKLIB,$@, $^)
+	$(V_MKLIB)$(call MKLIB,$@, $^)
 
 runtime/libasmrund.$(A): $(libasmrund_OBJECTS)
-	$(call MKLIB,$@, $^)
+	$(V_MKLIB)$(call MKLIB,$@, $^)
 
 runtime/libasmruni.$(A): $(libasmruni_OBJECTS)
-	$(call MKLIB,$@, $^)
+	$(V_MKLIB)$(call MKLIB,$@, $^)
 
 runtime/libasmrun_pic.$(A): $(libasmrunpic_OBJECTS)
-	$(call MKLIB,$@, $^)
+	$(V_MKLIB)$(call MKLIB,$@, $^)
 
 runtime/libasmrun_shared.$(SO): $(libasmrunpic_OBJECTS)
-	$(MKDLL) -o $@ $^ $(NATIVECCLIBS)
+	$(V_MKDLL)$(MKDLL) -o $@ $^ $(NATIVECCLIBS)
 
 ## Runtime target-specific preprocessor and compiler flags
 
@@ -974,45 +974,45 @@ ASPP_ERROR = \
           echo "try producing $*.o by hand.";\
           exit 2; }
 runtime/%.o: runtime/%.S
-	$(ASPP) $(OC_ASPPFLAGS) -o $@ $< || $(ASPP_ERROR)
+	$(V_ASM)$(ASPP) $(OC_ASPPFLAGS) -o $@ $< || $(ASPP_ERROR)
 
 runtime/%.d.o: runtime/%.S
-	$(ASPP) $(OC_ASPPFLAGS) $(OC_DEBUG_CPPFLAGS) -o $@ $< || $(ASPP_ERROR)
+	$(V_ASM)$(ASPP) $(OC_ASPPFLAGS) $(OC_DEBUG_CPPFLAGS) -o $@ $< || $(ASPP_ERROR)
 
 runtime/%.i.o: runtime/%.S
-	$(ASPP) $(OC_ASPPFLAGS) $(OC_INSTR_CPPFLAGS) -o $@ $< || $(ASPP_ERROR)
+	$(V_ASM)$(ASPP) $(OC_ASPPFLAGS) $(OC_INSTR_CPPFLAGS) -o $@ $< || $(ASPP_ERROR)
 
 runtime/%_libasmrunpic.o: runtime/%.S
-	$(ASPP) $(OC_ASPPFLAGS) $(SHAREDLIB_CFLAGS) -o $@ $<
+	$(V_ASM)$(ASPP) $(OC_ASPPFLAGS) $(SHAREDLIB_CFLAGS) -o $@ $<
 
 runtime/domain_state64.inc: \
   runtime/gen_domain_state64_inc.awk runtime/caml/domain_state.tbl
-	$(AWK) -f $^ > $@
+	$(V_GEN)$(AWK) -f $^ > $@
 
 runtime/domain_state32.inc: \
   runtime/gen_domain_state32_inc.awk runtime/caml/domain_state.tbl
-	$(AWK) -f $^ > $@
+	$(V_GEN)$(AWK) -f $^ > $@
 
 runtime/amd64nt.obj: runtime/amd64nt.asm runtime/domain_state64.inc
-	$(ASM)$@ $<
+	$(V_ASM)$(ASM)$@ $<
 
 runtime/i386nt.obj: runtime/i386nt.asm runtime/domain_state32.inc
-	$(ASM)$@ $<
+	$(V_ASM)$(ASM)$@ $<
 
 runtime/amd64nt.d.obj: runtime/amd64nt.asm runtime/domain_state64.inc
-	$(ASM)$@ $(ocamlrund_CPPFLAGS) $<
+	$(V_ASM)$(ASM)$@ $(ocamlrund_CPPFLAGS) $<
 
 runtime/i386nt.d.obj: runtime/i386nt.asm runtime/domain_state32.inc
-	$(ASM)$@ $(ocmalrund_CPPFLAGS) $<
+	$(V_ASM)$(ASM)$@ $(ocmalrund_CPPFLAGS) $<
 
 runtime/amd64nt.i.obj: runtime/amd64nt.asm runtime/domain_state64.inc
-	$(ASM)$@ $(ocamlruni_CPPFLAGS) $<
+	$(V_ASM)$(ASM)$@ $(ocamlruni_CPPFLAGS) $<
 
 runtime/i386nt.i.obj: runtime/i386nt.asm runtime/domain_state32.inc
-	$(ASM)$@ $(ocamlruni_CPPFLAGS) $<
+	$(V_ASM)$(ASM)$@ $(ocamlruni_CPPFLAGS) $<
 
 runtime/%_libasmrunpic.obj: runtime/%.asm
-	$(ASM)$@ $<
+	$(V_ASM)$(ASM)$@ $<
 
 ## Runtime dependencies
 
@@ -1044,7 +1044,7 @@ endif
 .PHONY: makeruntime
 makeruntime: runtime-all
 stdlib/libcamlrun.$(A): runtime-all
-	cd stdlib; $(LN) ../runtime/libcamlrun.$(A) .
+	$(V_LN)cd stdlib; $(LN) ../runtime/libcamlrun.$(A) .
 clean::
 	rm -f $(addprefix runtime/, *.o *.obj *.a *.lib *.so *.dll ld.conf)
 	rm -f $(addprefix runtime/, ocamlrun ocamlrund ocamlruni ocamlruns sak)
@@ -1144,7 +1144,7 @@ ocamlyacc_CPPFLAGS = -DNDEBUG
 ocamlyacc: $(ocamlyacc_PROGRAM)$(EXE)
 
 $(ocamlyacc_PROGRAM)$(EXE): $(ocamlyacc_OBJECTS)
-	$(MKEXE) -o $@ $^
+	$(V_MKEXE)$(MKEXE) -o $@ $^
 
 clean::
 	rm -f $(ocamlyacc_MODULES:=.o) $(ocamlyacc_MODULES:=.obj)
@@ -1176,9 +1176,9 @@ include Makefile.menhir
 # generated parser.ml.
 
 parsing/camlinternalMenhirLib.ml: boot/menhir/menhirLib.ml
-	cp $< $@
+	$(V_GEN)cp $< $@
 parsing/camlinternalMenhirLib.mli: boot/menhir/menhirLib.mli
-	echo '[@@@ocaml.warning "-67"]' > $@
+	$(V_GEN)echo '[@@@ocaml.warning "-67"]' > $@ && \
 	cat $< >> $@
 
 # Copy parsing/parser.ml from boot/
@@ -1193,9 +1193,9 @@ parsing/parser.ml: $(PARSER_DEPS)
 ifeq "$(OCAML_DEVELOPMENT_VERSION)" "true"
 	@-tools/check-parser-uptodate-or-warn.sh
 endif
-	sed "s/MenhirLib/CamlinternalMenhirLib/g" $< > $@
+	$(V_GEN)sed "s/MenhirLib/CamlinternalMenhirLib/g" $< > $@
 parsing/parser.mli: boot/menhir/parser.mli
-	sed "s/MenhirLib/CamlinternalMenhirLib/g" $< > $@
+	$(V_GEN)sed "s/MenhirLib/CamlinternalMenhirLib/g" $< > $@
 
 beforedepend:: parsing/camlinternalMenhirLib.ml \
   parsing/camlinternalMenhirLib.mli \
@@ -1286,7 +1286,7 @@ checkstack: tools/checkstack$(EXE)
 
 .INTERMEDIATE: tools/checkstack$(EXE) tools/checkstack.$(O)
 tools/checkstack$(EXE): tools/checkstack.$(O)
-	$(MKEXE) $(OUTPUTEXE)$@ $<
+	$(V_MKEXE)$(MKEXE) $(OUTPUTEXE)$@ $<
 else
 checkstack:
 	@
@@ -1410,7 +1410,7 @@ make_opcodes_LIBRARIES =
 make_opcodes_MODULES = tools/make_opcodes
 
 tools/opnames.ml: runtime/caml/instruct.h $(make_opcodes)
-	$(NEW_OCAMLRUN) $(make_opcodes) -opnames < $< > $@
+	$(V_GEN)$(NEW_OCAMLRUN) $(make_opcodes) -opnames < $< > $@
 
 clean::
 	rm -f $(addprefix tools/,opnames.ml make_opcodes.ml)
@@ -1523,10 +1523,10 @@ toplevel/native/topeval.cmx: otherlibs/dynlink/dynlink.cmxa
 # The numeric opcodes
 
 bytecomp/opcodes.ml: runtime/caml/instruct.h $(make_opcodes)
-	$(NEW_OCAMLRUN) $(make_opcodes) -opcodes < $< > $@
+	$(V_GEN)$(NEW_OCAMLRUN) $(make_opcodes) -opcodes < $< > $@
 
 bytecomp/opcodes.mli: bytecomp/opcodes.ml
-	$(CAMLC) -i $< > $@
+	$(V_GEN)$(CAMLC) -i $< > $@
 
 partialclean::
 	rm -f bytecomp/opcodes.ml
@@ -1560,7 +1560,7 @@ partialclean::
 
 .PHONY: depend
 depend: beforedepend
-	(for d in utils parsing typing bytecomp asmcomp middle_end \
+	$(V_GEN)(for d in utils parsing typing bytecomp asmcomp middle_end \
          lambda file_formats middle_end/closure middle_end/flambda \
          middle_end/flambda/base_types \
          driver toplevel toplevel/byte toplevel/native lex tools; \

--- a/Makefile.common
+++ b/Makefile.common
@@ -146,8 +146,7 @@ REQUIRED_HEADERS := $(RUNTIME_HEADERS) $(wildcard *.h)
 endif
 
 %.$(O): %.c $(REQUIRED_HEADERS)
-	$(info CC $< -> $@)
-	@$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
+	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
 	  $(OUTPUTOBJ)$@ $<
 
 $(DEPDIR):

--- a/Makefile.common
+++ b/Makefile.common
@@ -28,6 +28,26 @@ EMPTY :=
 # $(SPACE) contains a single space
 SPACE := $(EMPTY) $(EMPTY)
 
+V_AR         = @$(info $   AR           $@)
+V_CC         = @$(info $   CC           $@)
+V_CCDEPS     = @$(info $   CCDEPS       $@)
+V_OCAMLC     = @$(info $   OCAMLC       $@)
+V_OCAMLOPT   = @$(info $   OCAMLOPT     $@)
+V_GEN        = @$(info $   GEN          $@)
+V_LINKC      = @$(info $   LINKC        $@)
+V_LINKOPT    = @$(info $   LINKOPT      $@)
+V_MKEXE      = @$(info $   MKEXE        $@)
+V_MKLIB      = @$(info $   MKLIB        $@)
+V_MKDLL      = @$(info $   MKDLL        $@)
+V_OCAMLLEX   = @$(info $   OCAMLLEX     $@)
+V_OCAMLYACC  = @$(info $   OCAMLYACC    $@)
+V_OCAMLDEP   = @$(info $   OCAMLDEP     $@)
+V_LN         = @$(info $   LN           $@)
+V_ASM        = @$(info $   ASM          $@)
+V_OCAMLMKLIB = @$(info $   OCAMLMKLIB   $@)
+V_OCAMLDOC   = @$(info $   OCAMLDOC     $@)
+V_ODOC       = @$(info $   ODOC         $@)
+
 DESTDIR ?=
 INSTALL_BINDIR := $(DESTDIR)$(BINDIR)
 INSTALL_LIBDIR := $(DESTDIR)$(LIBDIR)

--- a/Makefile.common
+++ b/Makefile.common
@@ -186,7 +186,7 @@ OCAMLLEX ?= $(BEST_OCAMLLEX)
 OCAMLLEXFLAGS ?= -q
 
 %.ml: %.mll
-	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
+	$(V_OCAMLLEX)$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
 
 # Parser generation
 
@@ -195,7 +195,7 @@ OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
 OCAMLYACCFLAGS ?= --strict -v
 
 %.ml %.mli: %.mly
-	$(OCAMLYACC) $(OCAMLYACCFLAGS) $<
+	$(V_OCAMLYACC)$(OCAMLYACC) $(OCAMLYACCFLAGS) $<
 
 SAK = $(ROOTDIR)/runtime/sak$(EXE)
 
@@ -234,7 +234,7 @@ $(eval $(call PROGRAM_SYNONYM,$(1)))
 $(1)$(EXE): \
   $$$$(patsubst %,%.cma, $$$$($(basename $(notdir $(1)))_LIBRARIES)) \
   $$$$(patsubst %,%.cmo, $$$$($(basename $(notdir $(1)))_MODULES))
-	$$(LINK_BYTECODE_PROGRAM) -o $$@ $$^
+	$$(V_LINKC)$$(LINK_BYTECODE_PROGRAM) -o $$@ $$^
 endef # OCAML_BYTECODE_PROGRAM
 
 LINK_NATIVE_PROGRAM =\
@@ -245,7 +245,7 @@ $(eval $(call PROGRAM_SYNONYM,$(1)))
 $(1)$(EXE): \
   $$$$(patsubst %,%.cmxa, $$$$($(basename $(notdir $(1)))_LIBRARIES)) \
   $$$$(patsubst %,%.cmx, $$$$($(basename $(notdir $(1)))_MODULES))
-	$$(LINK_NATIVE_PROGRAM) -o $$@ $$^
+	$$(V_LINKOPT)$$(LINK_NATIVE_PROGRAM) -o $$@ $$^
 endef # OCAML_NATIVE_PROGRAM
 
 define OCAML_PROGRAM

--- a/api_docgen/Makefile.common
+++ b/api_docgen/Makefile.common
@@ -42,12 +42,12 @@ build/latex/alldoc.pdf: build/latex/stdlib_input.tex \
   build/latex/compilerlibs_input.tex | build/latex/ifocamldoc.tex
 
 build/Compiler_libs.mld: $(DOCGEN)/Compiler_libs.pre.mld | build/
-	cp $< $@ && echo "{!modules:$(compilerlibref_C)}" >> $@
+	$(V_GEN)cp $< $@ && echo "{!modules:$(compilerlibref_C)}" >> $@
 
 build/latex/ifocamldoc.tex: $(ROOTDIR)/Makefile.config | build/latex
 
 build/latex/alldoc.tex:$(DOCGEN)/alldoc.tex | build/latex
-	cp $< $@
+	$(V_GEN)cp $< $@
 
 build/%.mld: $(DOCGEN)/%.mld | build/
-	cp $< $@
+	$(V_GEN)cp $< $@

--- a/api_docgen/ocamldoc/Makefile
+++ b/api_docgen/ocamldoc/Makefile
@@ -38,56 +38,56 @@ ALL_MAN= $(ALL_DOC:%=build/man/%.3o)
 ALL_LATEX= $(ALL_DOC:%=build/latex/%.tex)
 
 build/latex/ifocamldoc.tex: | build/latex
-	printf '\\newif\\ifocamldoc\\ocamldoctrue\n' > $@
+	$(V_GEN)printf '\\newif\\ifocamldoc\\ocamldoctrue\n' > $@
 
 $(libref:%=build/libref/%.odoc): build/libref/%.odoc: %.mli | build/libref
-	$(OCAMLDOC_RUN) -nostdlib -hide Stdlib -lib Stdlib \
+	$(V_OCAMLDOC)$(OCAMLDOC_RUN) -nostdlib -hide Stdlib -lib Stdlib \
 	-pp \
 "$(AWK) -v ocamldoc=true -f ../../stdlib/expand_module_aliases.awk" \
 	$(DOC_STDLIB_INCLUDES) -hide-warnings  $< -dump  $@
 
 $(compilerlibref:%=build/compilerlibref/%.odoc):\
 build/compilerlibref/%.odoc: %.mli | build/compilerlibref
-	$(OCAMLDOC_RUN) -nostdlib -hide Stdlib \
+	$(V_OCAMLDOC)$(OCAMLDOC_RUN) -nostdlib -hide Stdlib \
 	$(DOC_ALL_INCLUDES) -hide-warnings $< -dump  $@
 
 $(compilerlibref_TEXT:%=build/compilerlibref/%.odoc):\
 build/compilerlibref/%.odoc: build/%.mld | build/compilerlibref
-	$(OCAMLDOC_RUN)  -hide-warnings $(DOC_ALL_INCLUDES) -text $< -dump  $@
+	$(V_OCAMLDOC)$(OCAMLDOC_RUN)  -hide-warnings $(DOC_ALL_INCLUDES) -text $< -dump  $@
 
 $(libref_TEXT:%=build/libref/%.odoc):\
 build/libref/%.odoc: build/%.mld | build/libref
-	$(OCAMLDOC_RUN) -hide-warnings $(DOC_STDLIB_INCLUDES) -text $< -dump  $@
+	$(V_OCAMLDOC)$(OCAMLDOC_RUN) -hide-warnings $(DOC_STDLIB_INCLUDES) -text $< -dump  $@
 
 ALL_COMPILED_DOC=$(ALL_DOC:%=build/%.odoc)
 build/man/Stdlib.3o: $(ALL_COMPILED_DOC) | build/man
-	$(OCAMLDOC_RUN) -man -d build/man -man-mini \
+	$(V_OCAMLDOC)$(OCAMLDOC_RUN) -man -d build/man -man-mini \
 	-nostdlib -hide Stdlib -lib Stdlib -t "OCaml library" \
 	$(addprefix -load , $(ALL_COMPILED_DOC))
 
 HTML_OPTIONS= -charset="utf8" -colorize-code -nonavbar
 
 build/html/libref/Stdlib.html: $(ALL_LIBREF:%=build/%.odoc) | build/html/libref
-	$(OCAMLDOC_RUN) -html -d build/html/libref \
+	$(V_OCAMLDOC)$(OCAMLDOC_RUN) -html -d build/html/libref \
 	$(HTML_OPTIONS) \
 	-nostdlib -hide Stdlib -lib Stdlib -t "OCaml library" \
 	$(addprefix -load , $(ALL_LIBREF:%=build/%.odoc))
 
 build/html/compilerlibref/Compiler_libs.html: \
   $(ALL_COMPILERLIBREF:%=build/%.odoc) | build/html/compilerlibref
-	$(OCAMLDOC_RUN) -html -d build/html/compilerlibref \
+	$(V_OCAMLDOC)$(OCAMLDOC_RUN) -html -d build/html/compilerlibref \
 	-nostdlib -hide Stdlib -t "OCaml compiler library" \
 	$(HTML_OPTIONS) \
 	-intro build/Compiler_libs.mld \
 	$(addprefix -load , $(ALL_COMPILERLIBREF:%=build/%.odoc))
 
 build/texi/stdlib.texi: $(ALL_COMPILED_DOC) | build/texi
-	$(OCAMLDOC_RUN) -texi -o $@ \
+	$(V_OCAMLDOC)$(OCAMLDOC_RUN) -texi -o $@ \
 	-nostdlib -hide Stdlib -lib Stdlib -t "OCaml library" \
 	$(addprefix -load , $(ALL_COMPILED_DOC))
 
 build/latex/Stdlib.tex: $(ALL_COMPILED_DOC) | build/latex
-	$(OCAMLDOC_RUN) -latex -o build/latex/all.tex \
+	$(V_OCAMLDOC)$(OCAMLDOC_RUN) -latex -o build/latex/all.tex \
 	-hide Stdlib -lib Stdlib $(DOC_ALL_INCLUDES) \
 	-sepfiles \
 	-latextitle "1,subsection*" \
@@ -111,13 +111,13 @@ $(filter-out stdlib.mli camlinternal%,$(stdlib_UNPREFIXED)),\
 \\input{$(call capitalize,$(module)).tex}\
 )
 build/latex/stdlib_input.tex: | build/latex
-	echo $(stdlib_INPUT) > $@
+	$(V_GEN)echo $(stdlib_INPUT) > $@
 
 compilerlibs_INPUT=$(foreach module,\
 $(filter-out camlinternal%,$(compilerlibref)),\
 \\input{$(call capitalize,$(module)).tex})
 build/latex/compilerlibs_input.tex: | build/latex
-	echo $(compilerlibs_INPUT) > $@
+	$(V_GEN)echo $(compilerlibs_INPUT) > $@
 
 .PHONY: install
 install:

--- a/api_docgen/odoc/Makefile
+++ b/api_docgen/odoc/Makefile
@@ -42,7 +42,7 @@ endef
 
 # define the right conditional for the manual
 build/latex/ifocamldoc.tex: | build/latex
-	printf '\\newif\\ifocamldoc\\ocamldocfalse\n' > $@
+	$(V_GEN)printf '\\newif\\ifocamldoc\\ocamldocfalse\n' > $@
 
 
 # \input{} all modules in the stdlib for the latex api manual
@@ -52,10 +52,10 @@ $(filter-out stdlib camlinternal%, $(STDLIB:stdlib__%=%)),\
 )
 
 build/latex/stdlib_input.tex: | build/latex
-	echo $(stdlib_INPUT)> $@
+	$(V_GEN)echo $(stdlib_INPUT)> $@
 
 build/latex/compilerlibs_input.tex: | build/latex
-	echo $(compilerlibref_C:%=\\input{compilerlibref/%})> $@
+	$(V_GEN)echo $(compilerlibref_C:%=\\input{compilerlibref/%})> $@
 
 # The build process for odoc has 3 phases:
 # 1. generation of internal individual documentation files  (.odoc)
@@ -65,26 +65,26 @@ build/latex/compilerlibs_input.tex: | build/latex
 # rules for the mld files
 $(libref_TEXT:%=build/libref/page-%.odoc):
 build/libref/page-%.odoc: build/%.mld | build/libref
-	$(odoc) compile -I build/libref --package libref $< -o $@
+	$(V_ODOC)$(odoc) compile -I build/libref --package libref $< -o $@
 
 $(compilerlibref_TEXT:%=build/compilerlibref/page-%.odoc):\
 build/compilerlibref/page-%.odoc: build/%.mld | build/compilerlibref
-	$(odoc) compile -I build/libref --package compilerlibref $< -o $@
+	$(V_ODOC)$(odoc) compile -I build/libref --package compilerlibref $< -o $@
 
 # rules for the stdlib and otherlibs .doc files
 $(libref:%=build/libref/%.odoc):\
 build/libref/%.odoc: %.cmti | build/libref
-	$(odoc) compile -I build/libref  --package libref $< -o $@
+	$(V_ODOC)$(odoc) compile -I build/libref  --package libref $< -o $@
 
 # pervasives is handled separatedly due to the lack of cmti file
 $(libref_EXTRA:%=build/libref/%.odoc):build/libref/%.odoc:%.cmt
-	$(odoc) compile -I build/libref --package libref $< -o $@
+	$(V_ODOC)$(odoc) compile -I build/libref --package libref $< -o $@
 
 # rules for the compilerlib documentation
 $(compilerlibref:%=build/compilerlibref/%.odoc):\
 build/compilerlibref/%.odoc: %.cmti $(libref:%=build/libref/%.odoc) \
 | build/compilerlibref
-	$(odoc) compile -I build/libref -I build/compilerlibref \
+	$(V_ODOC)$(odoc) compile -I build/libref -I build/compilerlibref \
 	--package compilerlibref $< -o $@
 
 ALL_TEXT = $(libref_TEXT:%=libref/%) $(compilerlibref_TEXT:%=compilerlibref/%)
@@ -101,11 +101,11 @@ ALL_PAGED_DOC = $(TARGET_UNITS) $(ALL_PAGE_TEXT)
 # the individual file dependencies
 %.odocl:%.odoc \
   | $(ALL_PAGED_DOC:%=build/%.odoc)
-	$(odoc) link -I build/libref -I build/compilerlibref $(ODOC_LINK_ARGS) $<
+	$(V_ODOC)$(odoc) link -I build/libref -I build/compilerlibref $(ODOC_LINK_ARGS) $<
 
 %.odocl:%.odoc \
   | $(ALL_PAGED_DOC:%=build/%.odoc)
-	$(odoc) link -I build/libref -I build/compilerlibref $(ODOC_LINK_ARGS) $<
+	$(V_ODOC)$(odoc) link -I build/libref -I build/compilerlibref $(ODOC_LINK_ARGS) $<
 
 build/libref/stdlib.odocl: ODOC_LINK_ARGS+=--open=""
 
@@ -125,15 +125,15 @@ html: build/libref/index.html.stamp build/compilerlibref/index.html.stamp
 
 # Html rules
 $(ALL_HTML): %.html.stamp: %.odocl | build/html
-	$(odoc) html-generate --output-dir build/html  $<
+	$(V_ODOC)$(odoc) html-generate --output-dir build/html  $<
 	touch $@
 
 build/html/odoc.css: | build/html
-	$(odoc) support-files --output-dir build/html
+	$(V_ODOC)$(odoc) support-files --output-dir build/html
 
 $(build/libref.html.stamp build/compilerlibref.html.stamp):
 %.html.stamp: %.mld | build/
-	$(odoc) html-generate --output-dir build/html  $<
+	$(V_ODOC)$(odoc) html-generate --output-dir build/html  $<
 	touch $@
 
 # Html indexes for the api documentation

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -426,33 +426,33 @@ $(addprefix compilerlibs/,\
   CAMLC = $(BOOT_OCAMLC) $(BOOT_STDLIBFLAGS) -use-prims runtime/primitives
 
 compilerlibs/ocamlcommon.cma: $(COMMON_CMI) $(ALL_CONFIG_CMO) $(COMMON)
-	$(CAMLC) -a -linkall -o $@ $(COMMON)
+	$(V_LINKC)$(CAMLC) -a -linkall -o $@ $(COMMON)
 partialclean::
 	rm -f compilerlibs/ocamlcommon.cma
 
 compilerlibs/ocamlcommon.cmxa: $(COMMON_CMI) $(COMMON:.cmo=.cmx)
-	$(CAMLOPT) -a -linkall -o $@ $(COMMON:.cmo=.cmx)
+	$(V_LINKOPT)$(CAMLOPT) -a -linkall -o $@ $(COMMON:.cmo=.cmx)
 partialclean::
 	rm -f compilerlibs/ocamlcommon.cmxa \
 	      compilerlibs/ocamlcommon.a compilerlibs/ocamlcommon.lib
 
 
 compilerlibs/ocamlbytecomp.cma: $(BYTECOMP_CMI) $(BYTECOMP)
-	$(CAMLC) -a -o $@ $(BYTECOMP)
+	$(V_LINKC)$(CAMLC) -a -o $@ $(BYTECOMP)
 partialclean::
 	rm -f compilerlibs/ocamlbytecomp.cma
 
 compilerlibs/ocamlbytecomp.cmxa: $(BYTECOMP_CMI) $(BYTECOMP:.cmo=.cmx)
-	$(CAMLOPT) -a $(OCAML_NATDYNLINKOPTS) -o $@ $(BYTECOMP:.cmo=.cmx)
+	$(V_LINKOPT)$(CAMLOPT) -a $(OCAML_NATDYNLINKOPTS) -o $@ $(BYTECOMP:.cmo=.cmx)
 partialclean::
 	rm -f compilerlibs/ocamlbytecomp.cmxa \
 	      compilerlibs/ocamlbytecomp.a compilerlibs/ocamlbytecomp.lib
 
 
 compilerlibs/ocamlmiddleend.cma: $(MIDDLE_END_CMI) $(MIDDLE_END)
-	$(CAMLC) -a -o $@ $(MIDDLE_END)
+	$(V_LINKC)$(CAMLC) -a -o $@ $(MIDDLE_END)
 compilerlibs/ocamlmiddleend.cmxa: $(MIDDLE_END_CMI) $(MIDDLE_END:%.cmo=%.cmx)
-	$(CAMLOPT) -a -o $@ $(MIDDLE_END:%.cmo=%.cmx)
+	$(V_LINKOPT)$(CAMLOPT) -a -o $@ $(MIDDLE_END:%.cmo=%.cmx)
 partialclean::
 	rm -f compilerlibs/ocamlmiddleend.cma \
 	      compilerlibs/ocamlmiddleend.cmxa \
@@ -461,24 +461,24 @@ partialclean::
 
 
 compilerlibs/ocamloptcomp.cma: $(OPTCOMP_CMI) $(OPTCOMP)
-	$(CAMLC) -a -o $@ $(OPTCOMP)
+	$(V_LINKC)$(CAMLC) -a -o $@ $(OPTCOMP)
 partialclean::
 	rm -f compilerlibs/ocamloptcomp.cma
 
 compilerlibs/ocamloptcomp.cmxa: $(OPTCOMP_CMI) $(OPTCOMP:.cmo=.cmx)
-	$(CAMLOPT) -a -o $@ $(OPTCOMP:.cmo=.cmx)
+	$(V_LINKOPT)$(CAMLOPT) -a -o $@ $(OPTCOMP:.cmo=.cmx)
 partialclean::
 	rm -f compilerlibs/ocamloptcomp.cmxa \
 	      compilerlibs/ocamloptcomp.a compilerlibs/ocamloptcomp.lib
 
 
 compilerlibs/ocamltoplevel.cma: $(TOPLEVEL_CMI) $(TOPLEVEL)
-	$(CAMLC) -a -o $@ -I toplevel/byte $(TOPLEVEL)
+	$(V_LINKC)$(CAMLC) -a -o $@ -I toplevel/byte $(TOPLEVEL)
 partialclean::
 	rm -f compilerlibs/ocamltoplevel.cma
 
 compilerlibs/ocamltoplevel.cmxa: $(OPTTOPLEVEL_CMI) $(OPTTOPLEVEL:.cmo=.cmx)
-	$(CAMLOPT) -a -o $@ -I toplevel/native $(OPTTOPLEVEL:.cmo=.cmx)
+	$(V_LINKOPT)$(CAMLOPT) -a -o $@ -I toplevel/native $(OPTTOPLEVEL:.cmo=.cmx)
 partialclean::
 	rm -f compilerlibs/ocamltoplevel.cmxa \
 	  compilerlibs/ocamltoplevel.a compilerlibs/ocamltoplevel.lib

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -52,11 +52,11 @@ libraries = $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
 all: ocamldebug$(EXE)
 
 ocamldebug.cmo: $(debugger_objects)
-	$(CAMLC) -pack $(COMPFLAGS) -o $@ $^
+	$(V_OCAMLC)$(CAMLC) -pack $(COMPFLAGS) -o $@ $^
 
 ocamldebug$(EXE): $(libraries) $(compiler_objects) ocamldebug.cmo \
     ocamldebug_entry.cmo
-	$(CAMLC) $(LINKFLAGS) -o $@ -linkall $^
+	$(V_LINKC)$(CAMLC) $(LINKFLAGS) -o $@ -linkall $^
 
 install:
 	$(INSTALL_PROG) ocamldebug$(EXE) "$(INSTALL_BINDIR)"
@@ -70,16 +70,16 @@ clean::
 distclean: clean
 
 ocamldebug_entry.cmo: ocamldebug_entry.ml ocamldebug.cmo
-	$(CAMLC) -c $(COMPFLAGS) $<
+	$(V_OCAMLC)$(CAMLC) -c $(COMPFLAGS) $<
 
 %.cmo: %.ml
-	$(CAMLC) -c $(COMPFLAGS) -for-pack ocamldebug $<
+	$(V_OCAMLC)$(CAMLC) -c $(COMPFLAGS) -for-pack ocamldebug $<
 
 %.cmi: %.mli
-	$(CAMLC) -c $(COMPFLAGS) -for-pack ocamldebug $<
+	$(V_OCAMLC)$(CAMLC) -c $(COMPFLAGS) -for-pack ocamldebug $<
 
 depend: beforedepend
-	$(OCAMLDEP_CMD) *.mli *.ml > .depend
+	$(V_OCAMLDEP)$(OCAMLDEP_CMD) *.mli *.ml > .depend
 
 clean::
 	rm -f debugger_lexer.ml

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -162,18 +162,18 @@ OCAMLDOC_NCLIBRARIES = $(OCAMLDOC_LIBRARIES:%=%.cmxa)
 $(eval $(call PROGRAM_SYNONYM,ocamldoc))
 
 $(OCAMLDOC): $(EXECMOFILES)
-	$(OCAMLC) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_BCLIBRARIES) $^
+	$(V_LINKC)$(OCAMLC) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_BCLIBRARIES) $^
 
 $(eval $(call PROGRAM_SYNONYM,ocamldoc.opt))
 
 $(OCAMLDOC_OPT): $(EXECMXFILES)
-	$(OCAMLOPT_CMD) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_NCLIBRARIES) $^
+	$(V_LINKOPT)$(OCAMLOPT_CMD) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_NCLIBRARIES) $^
 
 $(OCAMLDOC_LIBCMA): $(LIBCMOFILES)
-	$(OCAMLC) -a -o $@ $(LINKFLAGS) $^
+	$(V_LINKC)$(OCAMLC) -a -o $@ $(LINKFLAGS) $^
 
 $(OCAMLDOC_LIBCMXA): $(LIBCMXFILES)
-	$(OCAMLOPT) -a -o $@ $(LINKFLAGS) $^
+	$(V_LINKOPT)$(OCAMLOPT) -a -o $@ $(LINKFLAGS) $^
 
 .PHONY: dot
 dot: ocamldoc.dot
@@ -195,16 +195,16 @@ DEPEND_PREREQS = $(LEXERS:.mll=.ml) \
 #################
 
 %.cmo: %.ml
-	$(OCAMLC) $(COMPFLAGS) -c $<
+	$(V_OCAMLC)$(OCAMLC) $(COMPFLAGS) -c $<
 
 %.cmi: %.mli
-	$(OCAMLC) $(COMPFLAGS) -c $<
+	$(V_OCAMLC)$(OCAMLC) $(COMPFLAGS) -c $<
 
 %.cmx: %.ml
-	$(OCAMLOPT) $(COMPFLAGS) -c $<
+	$(V_OCAMLOPT)$(OCAMLOPT) $(COMPFLAGS) -c $<
 
 %.cmxs: %.ml
-	$(OCAMLOPT_CMD) -shared -o $@ $(COMPFLAGS) $<
+	$(V_OCAMLOPT)$(OCAMLOPT_CMD) -shared -o $@ $(COMPFLAGS) $<
 
 # Installation targets
 ######################

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -135,24 +135,24 @@ $(eval $(call PROGRAM_SYNONYM,ocamltest))
 ocamltest_unix.%: flags+=$(ocamltest_unix_include) -opaque
 
 ocamltest$(EXE): $(deps_byte) $(bytecode_modules)
-	$(ocamlc_cmd) $(ocamltest_unix_include)-custom -o $@ $^
+	$(V_LINKC)$(ocamlc_cmd) $(ocamltest_unix_include)-custom -o $@ $^
 
 %.cmo: %.ml $(deps_byte)
-	$(ocamlc) -c $<
+	$(V_OCAMLC)$(ocamlc) -c $<
 
 $(eval $(call PROGRAM_SYNONYM,ocamltest.opt))
 
 ocamltest.opt$(EXE): $(deps_opt) $(native_modules)
-	$(ocamlopt_cmd) $(ocamltest_unix_include)-o $@ $^
+	$(V_LINKOPT)$(ocamlopt_cmd) $(ocamltest_unix_include)-o $@ $^
 
 %.cmx: %.ml $(deps_opt)
-	$(ocamlopt) -c $<
+	$(V_OCAMLOPT)$(ocamlopt) -c $<
 
 %.cmi: %.mli $(deps_byte)
-	$(ocamlc) -c $<
+	$(V_OCAMLC)$(ocamlc) -c $<
 
 ocamltest_unix.ml: ocamltest_unix_$(ocamltest_unix_impl).ml
-	echo '# 1 "$<"' > $@
+	$(V_GEN)echo '# 1 "$<"' > $@ && \
 	cat $< >> $@
 
 # Manual
@@ -181,10 +181,10 @@ distclean: clean
 	rm -f ocamltest_config.ml
 
 $(DEPDIR)/%.$(D): %.c | $(DEPDIR)
-	$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MT '$*.$(O)' -MF $@
+	$(V_CCDEPS)$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MT '$*.$(O)' -MF $@
 
 .PHONY: depend
 depend: $(dependencies_generated_prereqs)
-	$(OCAMLDEP_CMD) $(mli_files) $(ml_files) > .depend
+	$(V_OCAMLDEP)$(OCAMLDEP_CMD) $(mli_files) $(ml_files) > .depend
 
 -include .depend

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -156,25 +156,20 @@ distclean:: clean
 	rm -f META
 
 %.cmi: %.mli
-	$(info OCAMLC $<)
-	@$(CAMLC) -c $(COMPFLAGS) $<
+	$(V_OCAMLC)$(CAMLC) -c $(COMPFLAGS) $<
 
 %.cmo: %.ml
-	$(info OCAMLC $<)
-	@$(CAMLC) -c $(COMPFLAGS) $<
+	$(V_OCAMLC)$(CAMLC) -c $(COMPFLAGS) $<
 
 %.cmx: %.ml
-	$(info OCAMLOPT $<)
-	@$(CAMLOPT) -c $(COMPFLAGS) $(OPTCOMPFLAGS) $<
+	$(V_OCAMLOPT)$(CAMLOPT) -c $(COMPFLAGS) $(OPTCOMPFLAGS) $<
 
 %.b.$(O): %.c $(REQUIRED_HEADERS)
-	$(info CC $< -> $@)
-	@$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
+	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
 	  $(OUTPUTOBJ)$@ $<
 
 %.n.$(O): %.c $(REQUIRED_HEADERS)
-	$(info CC $< -> $@)
-	@$(CC) -c $(OC_CFLAGS) $(OC_NATIVE_C_FLAGS) $(CFLAGS) \
+	$(V_CC)$(CC) -c $(OC_CFLAGS) $(OC_NATIVE_C_FLAGS) $(CFLAGS) \
 	  $(OC_CPPFLAGS) $(CPPFLAGS) $(OUTPUTOBJ)$@ $<
 
 ifeq "$(COMPUTE_DEPS)" "true"
@@ -184,5 +179,4 @@ endif
 endif
 
 $(DEPDIR)/%.$(D): %.c | $(DEPDIR)
-	$(info CCDEPS $< -> $@)
-	@$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MT '$*.$(O)' -MF $@
+	$(V_CCDEPS)$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MT '$*.$(O)' -MF $@

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -76,28 +76,28 @@ opt.opt: allopt
 
 $(LIBNAME).cma: $(CAMLOBJS)
 ifeq "$(COBJS)" ""
-	$(CAMLC) -o $@ -a -linkall $(CAMLOBJS) $(LINKOPTS)
+	$(V_LINKC)$(CAMLC) -o $@ -a -linkall $(CAMLOBJS) $(LINKOPTS)
 else
-	$(MKLIB) -o $(LIBNAME) -oc $(CLIBNAME_BYTECODE) -ocamlc '$(CAMLC)' \
+	$(V_OCAMLMKLIB)$(MKLIB) -o $(LIBNAME) -oc $(CLIBNAME_BYTECODE) -ocamlc '$(CAMLC)' \
                 -linkall $(CAMLOBJS) $(LINKOPTS)
 endif
 
 $(LIBNAME).cmxa: $(CAMLOBJS_NAT)
 ifeq "$(COBJS)" ""
-	$(CAMLOPT) -o $@ -a -linkall $(CAMLOBJS_NAT) $(LINKOPTS)
+	$(V_OCAMLOPT)$(CAMLOPT) -o $@ -a -linkall $(CAMLOBJS_NAT) $(LINKOPTS)
 else
-	$(MKLIB) -o $(LIBNAME) -oc $(CLIBNAME_NATIVE) -ocamlopt '$(CAMLOPT)' \
+	$(V_OCAMLMKLIB)$(MKLIB) -o $(LIBNAME) -oc $(CLIBNAME_NATIVE) -ocamlopt '$(CAMLOPT)' \
                 -linkall $(CAMLOBJS_NAT) $(LINKOPTS)
 endif
 
 $(LIBNAME).cmxs: $(LIBNAME).cmxa $(STUBSLIB_NATIVE)
-	$(CAMLOPT_CMD) -shared -o $(LIBNAME).cmxs -I . $(LIBNAME).cmxa
+	$(V_OCAMLOPT)$(CAMLOPT_CMD) -shared -o $(LIBNAME).cmxs -I . $(LIBNAME).cmxa
 
 lib$(CLIBNAME_BYTECODE).$(A): $(COBJS)
-	$(MKLIB_CMD) -oc $(CLIBNAME_BYTECODE) $(COBJS_BYTECODE) $(LDOPTS)
+	$(V_OCAMLMKLIB)$(MKLIB_CMD) -oc $(CLIBNAME_BYTECODE) $(COBJS_BYTECODE) $(LDOPTS)
 
 lib$(CLIBNAME_NATIVE).$(A): $(COBJS)
-	$(MKLIB_CMD) -oc $(CLIBNAME_NATIVE) $(COBJS_NATIVE) $(LDOPTS)
+	$(V_OCAMLMKLIB)$(MKLIB_CMD) -oc $(CLIBNAME_NATIVE) $(COBJS_NATIVE) $(LDOPTS)
 
 INSTALL_LIBDIR_LIBNAME = $(INSTALL_LIBDIR)/$(LIBNAME)
 

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -174,18 +174,15 @@ COMPILERLIBS_CMO=$(COMPILERLIBS_COPIED_SOURCES:.ml=.cmo)
 COMPILERLIBS_CMX=$(COMPILERLIBS_COPIED_SOURCES:.ml=.cmx)
 
 $(LOCAL_SRC)/%.cmi: $(LOCAL_SRC)/%.mli
-	$(info OCAMLC $<)
-	@$(OCAMLC) -c -for-pack Dynlink_compilerlibs $(COMPFLAGS) \
+	$(V_OCAMLC)$(OCAMLC) -c -for-pack Dynlink_compilerlibs $(COMPFLAGS) \
           -I $(LOCAL_SRC) -o $@ $(LOCAL_SRC)/$*.mli
 
 $(LOCAL_SRC)/%.cmo: $(LOCAL_SRC)/%.ml
-	$(info OCAMLC $<)
-	@$(OCAMLC) -c -for-pack Dynlink_compilerlibs $(COMPFLAGS) \
+	$(V_OCAMLC)$(OCAMLC) -c -for-pack Dynlink_compilerlibs $(COMPFLAGS) \
           -I $(LOCAL_SRC) -o $@ $(LOCAL_SRC)/$*.ml
 
 $(LOCAL_SRC)/%.cmx: $(LOCAL_SRC)/%.ml
-	$(info OCAMLOPT $<)
-	@$(OCAMLOPT) -c -for-pack Dynlink_compilerlibs $(COMPFLAGS) \
+	$(V_OCAMLOPT)$(OCAMLOPT) -c -for-pack Dynlink_compilerlibs $(COMPFLAGS) \
           $(OPTCOMPFLAGS) -I $(LOCAL_SRC) -o $@ $(LOCAL_SRC)/$*.ml
 
 # Rules for building the [Dynlink_compilerlibs] bytecode and native packs
@@ -299,13 +296,10 @@ depend: beforedepend
 include .depend
 
 %.cmi: %.mli
-	$(info OCAMLC $<)
-	@$(OCAMLC) -c $(COMPFLAGS) $<
+	$(V_OCAMLC)$(OCAMLC) -c $(COMPFLAGS) $<
 
 %.cmo: %.ml
-	$(info OCAMLC $<)
-	@$(OCAMLC) -c $(COMPFLAGS) $<
+	$(V_OCAMLC)$(OCAMLC) -c $(COMPFLAGS) $<
 
 %.cmx: %.ml
-	$(info OCAMLOPT $<)
-	@$(OCAMLOPT) -c $(COMPFLAGS) $(OPTCOMPFLAGS) $<
+	$(V_OCAMLOPT)$(OCAMLOPT) -c $(COMPFLAGS) $(OPTCOMPFLAGS) $<

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -124,13 +124,13 @@ COMPILERLIBS_SOURCES=\
 # Note: .ml-only modules are not supported by the (.mli.cmi) rule below.
 
 $(LOCAL_SRC)/Makefile: $(LOCAL_SRC)/Makefile.copy-sources Makefile
-	cp -f $< $@
+	$(V_GEN)cp -f $< $@ && \
 	for ml in $(COMPILERLIBS_SOURCES); do \
           echo "$(LOCAL_SRC)/$$(basename $$ml): $(ROOTDIR)/$$ml" \
             >> $@; \
           echo "$(LOCAL_SRC)/$$(basename $$ml)i: $(ROOTDIR)/$${ml}i" \
             >> $@; \
-        done;
+        done && \
 	for mli in $(COMPILERLIBS_INTFS); do \
           echo "$(LOCAL_SRC)/$$(basename $$mli): $(ROOTDIR)/$$mli" \
             >> $@; \
@@ -195,10 +195,10 @@ $(LOCAL_SRC)/%.cmx: $(LOCAL_SRC)/%.ml
 byt%/dynlink_compilerlibs.cmo byt%/dynlink_compilerlibs.cmi: $(COMPILERLIBS_CMO)
 	@$(if $(filter-out e,$*),\
         $(error Should only build byte/dynlink_compilerlibs.cmo!))
-	$(OCAMLC) $(COMPFLAGS) -pack -o byte/dynlink_compilerlibs.cmo $^
+	$(V_OCAMLC)$(OCAMLC) $(COMPFLAGS) -pack -o byte/dynlink_compilerlibs.cmo $^
 
 native/dynlink_compilerlibs.cmx: $(COMPILERLIBS_CMX)
-	$(OCAMLOPT) $(COMPFLAGS) $(OPTCOMPFLAGS) -pack -o $@ $(COMPILERLIBS_CMX)
+	$(V_OCAMLOPT)$(OCAMLOPT) $(COMPFLAGS) $(OPTCOMPFLAGS) -pack -o $@ $(COMPILERLIBS_CMX)
 
 %/dynlink.cmi: dynlink.cmi dynlink.mli
 	cp $^ $*/
@@ -215,10 +215,10 @@ all: dynlink.cma
 allopt: dynlink.cmxa
 
 dynlink.cma: $(OBJS)
-	$(OCAMLC) $(COMPFLAGS) -ccopt "$(NATDYNLINKOPTS)" -a -I byte -o $@ $^
+	$(V_LINKC)$(OCAMLC) $(COMPFLAGS) -ccopt "$(NATDYNLINKOPTS)" -a -I byte -o $@ $^
 
 dynlink.cmxa: $(NATOBJS)
-	$(OCAMLOPT) $(COMPFLAGS) -ccopt "$(NATDYNLINKOPTS)" -a -I native \
+	$(V_LINKOPT)$(OCAMLOPT) $(COMPFLAGS) -ccopt "$(NATDYNLINKOPTS)" -a -I native \
 	            -o $@ $^
 # As for all other .cmxa files, ensure that the .cmx files are in the same
 # directory. If this were omitted, ocamldoc in particular will fail to build
@@ -286,11 +286,11 @@ DEPEND_DUMMY_FILES=\
   native/dynlink.mli
 
 depend: beforedepend
-	touch $(DEPEND_DUMMY_FILES)
+	$(V_GEN)touch $(DEPEND_DUMMY_FILES) && \
 	$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash \
-	  -I byte -bytecode *.mli *.ml byte/dynlink.ml > .depend
+	  -I byte -bytecode *.mli *.ml byte/dynlink.ml > .depend && \
 	$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash \
-	  -I native -native *.ml native/dynlink.ml >> .depend
+	  -I native -native *.ml native/dynlink.ml >> .depend && \
 	rm -f $(DEPEND_DUMMY_FILES)
 
 include .depend

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -59,25 +59,25 @@ all: lib$(LIBNAME).$(A) $(LIBNAME).cma $(CMIFILES)
 allopt: lib$(LIBNAME)nat.$(A) $(LIBNAME).cmxa $(CMIFILES)
 
 lib$(LIBNAME).$(A): $(BYTECODE_C_OBJS)
-	$(MKLIB_CMD) -o $(LIBNAME) $(BYTECODE_C_OBJS)
+	$(V_OCAMLMKLIB)$(MKLIB_CMD) -o $(LIBNAME) $(BYTECODE_C_OBJS)
 
 lib$(LIBNAME)nat.$(A): $(NATIVECODE_C_OBJS)
-	$(MKLIB_CMD) -o $(LIBNAME)nat $^
+	$(V_OCAMLMKLIB)$(MKLIB_CMD) -o $(LIBNAME)nat $^
 
 $(LIBNAME).cma: $(THREADS_BCOBJS)
 ifeq "$(UNIX_OR_WIN32)" "unix"
-	$(MKLIB) -o $(LIBNAME) -ocamlc '$(CAMLC)' -cclib -lunixbyt -linkall $^
+	$(V_OCAMLMKLIB)$(MKLIB) -o $(LIBNAME) -ocamlc '$(CAMLC)' -cclib -lunixbyt -linkall $^
 # TODO: Figure out why -cclib -lunix is used here.
 # It may be because of the threadsUnix module which is deprecated.
 # It may hence be good to figure out whether this module shouldn't be
 # removed, and then -cclib -lunix arguments.
 else # Windows
-	$(MKLIB) -o $(LIBNAME) -ocamlc "$(CAMLC)" -linkall $^
+	$(V_OCAMLMKLIB)$(MKLIB) -o $(LIBNAME) -ocamlc "$(CAMLC)" -linkall $^
 endif
 
 # See remark above: force static linking of libthreadsnat.a
 $(LIBNAME).cmxa: $(THREADS_NCOBJS)
-	$(CAMLOPT) -linkall -a -cclib -lthreadsnat -o $@ $^
+	$(V_LINKOPT)$(CAMLOPT) -linkall -a -cclib -lthreadsnat -o $@ $^
 
 # Note: I removed "-cclib -lunix" from the line above.
 # Indeed, if we link threads.cmxa, then we must also link unix.cmxa,
@@ -169,6 +169,6 @@ $(foreach object_type, b n, $(eval $(call GEN_RULE,$(object_type))))
 
 .PHONY: depend
 depend:
-	$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend
+	$(V_GEN)$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend
 
 include .depend

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -95,8 +95,7 @@ st_stubs.%.$(O): st_stubs.c
 else
 st_stubs.%.$(O): st_stubs.c $(RUNTIME_HEADERS) $(wildcard *.h)
 endif
-	$(info CC $< -> $@)
-	@$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
+	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
 	  $(OUTPUTOBJ)$@ $<
 
 .PHONY: partialclean
@@ -163,8 +162,7 @@ endif
 
 define GEN_RULE
 $(DEPDIR)/%.$(1).$(D): %.c | $(DEPDIR)
-	$$(info CCDEPS $$< -> $$@)
-	@$$(DEP_CC) $$(OC_CPPFLAGS) $$(CPPFLAGS) $$< -MT '$$*.$(1).$(O)' -MF $$@
+	$$(V_CCDEPS)$$(DEP_CC) $$(OC_CPPFLAGS) $$(CPPFLAGS) $$< -MT '$$*.$(1).$(O)' -MF $$@
 endef
 
 $(foreach object_type, b n, $(eval $(call GEN_RULE,$(object_type))))

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -114,19 +114,19 @@ CAMLHEADERS =\
 ifeq "$(SHEBANGSCRIPTS)" "true"
 camlhead%: $(ROOTDIR)/Makefile.config Makefile
 ifeq "$(LONG_SHEBANG)" "true"
-	echo '#!/bin/sh' > $@
+	$(V_GEN)echo '#!/bin/sh' > $@ && \
 	echo 'exec "$(BINDIR)/ocamlrun$(subst er,,$*)" "$$0" "$$@"' >> $@
 else
-	echo '#!$(BINDIR)/ocamlrun$(subst er,,$*)' > $@
+	$(V_GEN)echo '#!$(BINDIR)/ocamlrun$(subst er,,$*)' > $@
 endif
 
 # TODO This does not take long shebangs into account (since TARGET_BINDIR is not
 #      yet processed by configure)
 target_%: $(ROOTDIR)/Makefile.config Makefile
-	echo '#!$(TARGET_BINDIR)/ocamlrun$(subst camlheader,,$*)' > $@
+	$(V_GEN)echo '#!$(TARGET_BINDIR)/ocamlrun$(subst camlheader,,$*)' > $@
 
 camlheader_ur: Makefile
-	echo '#!' | tr -d '\012' > $@
+	$(V_GEN)echo '#!' | tr -d '\012' > $@
 
 else # Hashbang scripts not supported
 
@@ -134,13 +134,13 @@ $(CAMLHEADERS): $(HEADERPROGRAM).c $(ROOTDIR)/Makefile.config Makefile
 
 # $@.exe is deleted to ensure no Cygwin .exe mangling takes place
 camlhead%: tmphead%.exe
-	rm -f $@.exe
+	$(V_GEN)rm -f $@.exe && \
 	mv $< $@
 
 # Again, pattern weirdness here means that the dot is always present so that
 # tmpheader.exe matches.
 tmpheader%exe: $(HEADERPROGRAM)%$(O)
-	$(call MKEXE_VIA_CC,$@,$^)
+	$(V_MKEXE)$(call MKEXE_VIA_CC,$@,$^)
 # FIXME This is wrong - mingw could invoke strip; MSVC equivalent?
 ifneq "$(UNIX_OR_WIN32)" "win32"
 	strip $@
@@ -150,37 +150,37 @@ $(HEADERPROGRAM)%$(O): \
   OC_CPPFLAGS += -DRUNTIME_NAME='"$(HEADER_PATH)ocamlrun$(subst .,,$*)"'
 
 $(HEADERPROGRAM)%$(O): $(HEADERPROGRAM).c
-	$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
+	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
 	  $(OUTPUTOBJ)$@ $^
 
 camlheader_ur: camlheader
-	cp camlheader $@
+	$(V_GEN)cp camlheader $@
 
 ifeq "$(UNIX_OR_WIN32)" "unix"
 tmptargetcamlheader%exe: $(TARGETHEADERPROGRAM)%$(O)
-	$(call MKEXE_VIA_CC,$@,$^)
+	$(V_MKEXE)$(call MKEXE_VIA_CC,$@,$^)
 	strip $@
 
 $(TARGETHEADERPROGRAM)%$(O): $(HEADERPROGRAM).c
-	$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
+	$(V_CC)$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
 	      -DRUNTIME_NAME='"$(HEADER_TARGET_PATH)ocamlrun$(subst .,,$*)"' \
 	      $(OUTPUTOBJ)$@ $^
 
 target_%: tmptarget%.exe
-	rm -f $@.exe
+	$(V_GEN)rm -f $@.exe && \
 	mv $< $@
 else
 target_%: %
-	cp $< $@
+	$(V_GEN)cp $< $@
 endif
 
 endif # ifeq "$(SHEBANGSCRIPTS)" "true"
 
 stdlib.cma: $(OBJS)
-	$(CAMLC) -a -o $@ $^
+	$(V_LINKC)$(CAMLC) -a -o $@ $^
 
 stdlib.cmxa: $(OBJS:.cmo=.cmx)
-	$(CAMLOPT) -a -o $@ $^
+	$(V_LINKOPT)$(CAMLOPT) -a -o $@ $^
 
 .PHONY: distclean
 distclean: clean
@@ -247,15 +247,15 @@ GNUISH_SED = \
 .INTERMEDIATE: .depend.tmp
 
 .depend.tmp:
-	$(OCAMLDEP_CMD) $(filter-out stdlib.%,$(wildcard *.mli *.ml)) > $@
-	$(OCAMLDEP_CMD) -pp "$(AWK) -f ./remove_module_aliases.awk" \
+	$(V_OCAMLDEP)$(OCAMLDEP_CMD) $(filter-out stdlib.%,$(wildcard *.mli *.ml)) > $@
+	$(V_OCAMLDEP)$(OCAMLDEP_CMD) -pp "$(AWK) -f ./remove_module_aliases.awk" \
 	  stdlib.ml stdlib.mli >> $@
 
 .PHONY: depend
 depend: .depend
 
 .depend: .depend.tmp
-	$(GNUISH_SED) -E \
+	$(V_GEN)$(GNUISH_SED) -E \
 	-e 's/^(${STDLIB_NAMESPACE_MODULES})(\.[^i]*)(i?) :/\1\2\3 : \1.ml\3/' \
 	-e 's#(^| )(${STDLIB_NAMESPACE_MODULES})[.]#\1stdlib__\u\2.#' \
 	$< > $@

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -193,36 +193,30 @@ clean::
 export AWK
 
 %.cmi: %.mli
-	$(info OCAMLC $<)
-	@$(CAMLC) $(COMPFLAGS) $(shell ./Compflags $@) -c $<
+	$(V_OCAMLC)$(CAMLC) $(COMPFLAGS) $(shell ./Compflags $@) -c $<
 
 # The dependency on the .mli file is in .depend (since stdlib__Foo.cmi
 # depends on stdlib__foo.mli)
 stdlib__%.cmi:
-	$(info OCAMLC $(filter %.mli, $^))
-	@$(CAMLC) $(COMPFLAGS) $(shell ./Compflags $@) \
+	$(V_OCAMLC)$(CAMLC) $(COMPFLAGS) $(shell ./Compflags $@) \
 	         -o $@ -c $(filter %.mli, $^)
 
 %.cmo: %.ml
-	$(info OCAMLC $<)
-	@$(CAMLC) $(COMPFLAGS) $(shell ./Compflags $@) -c $<
+	$(V_OCAMLC)$(CAMLC) $(COMPFLAGS) $(shell ./Compflags $@) -c $<
 
 # The dependency on the .ml file is in .depend (since stdlib__Foo.cmo
 # depends on stdlib__foo.ml)
 stdlib__%.cmo:
-	$(info OCAMLC $(filter %.ml, $^))
-	@$(CAMLC) $(COMPFLAGS) $(shell ./Compflags $@) \
+	$(V_OCAMLC)$(CAMLC) $(COMPFLAGS) $(shell ./Compflags $@) \
 	         -o $@ -c $(filter %.ml, $^)
 
 %.cmx: %.ml
-	$(info OCAMLOPT $<)
-	@$(CAMLOPT) $(COMPFLAGS) $(OPTCOMPFLAGS) $(shell ./Compflags $@) -c $<
+	$(V_OCAMLOPT)$(CAMLOPT) $(COMPFLAGS) $(OPTCOMPFLAGS) $(shell ./Compflags $@) -c $<
 
 # The dependency on the .ml file is in .depend (since stdlib__Foo.cmx
 # depends on stdlib__foo.ml)
 stdlib__%.cmx:
-	$(info OCAMLOPT $(filter %.ml, $^))
-	@$(CAMLOPT) $(COMPFLAGS) $(OPTCOMPFLAGS) $(shell ./Compflags $@) \
+	$(V_OCAMLOPT)$(CAMLOPT) $(COMPFLAGS) $(OPTCOMPFLAGS) $(shell ./Compflags $@) \
 	           -o $@ -c $(filter %.ml, $^)
 
 # Dependencies on the compiler


### PR DESCRIPTION
I played around with your nice PR, stealing some ideas from the Emacs sources (where they do the same thing). 

- Instead of printing the input file (and, sometimes, the output file) of each rule, print only the output file (this is clear enough 99% of the time). This allows a uniform handling of all rules (just print `$@`).

- Print trace lines with two leading spaces. This allows to quickly separate trace output from other types of outputs (`make` output, standard output of called programs, errors, etc).

- Instead of calling `$(info ...)` explicitly, hide this call behind a variable `$(V_XXX)`. Apart from sharing the strings that are printed, this also reduces the diff on the Makefile rules themselves: they can be written on the same line as the rule command, and it also hides the `@` directive. See `Makefile.common` for the full list of variables (first commit).

- Adapted many of the remaining uses. For linking commands I used `LINKC` and `LINKOPT` but we could use `OCAMLC` and `OCAMLOPT` as well. I used `GEN` as a fallback for several different kinds of rules that generate files.

- I think we can live for now without differentiating between `OCAMLC` and `OCAMLC.OPT`, etc (but would be nice to add in a later PR).

There is still a bit of work to do to get 100% coverage, but this gets us much closer to the goal I think.

Attached is the log resulting from the above modifications:

[log.txt](https://github.com/xavierleroy/ocaml/files/10334657/log.txt)
